### PR TITLE
Use string instead of Date

### DIFF
--- a/lib/schema_dot_org/comment.rb
+++ b/lib/schema_dot_org/comment.rb
@@ -1,8 +1,6 @@
 
 # frozen_string_literal: true
 
-require 'date'
-
 require_relative 'person'
 #
 # Model the Schema.org `Thing > CreativeWork > Comment`.  See https://schema.org/Comment
@@ -10,7 +8,7 @@ require_relative 'person'
 module SchemaDotOrg
   class Comment < SchemaType
     validated_attr :author,        type: Person, presence: true
-    validated_attr :datePublished, type: Date,   presence: true
+    validated_attr :datePublished, type: String, presence: true
 
     validated_attr :comment,              type: Array,  allow_nil: true
     validated_attr :creativeWorkStatus,   type: String, allow_nil: true

--- a/lib/schema_dot_org/discussion_forum_posting.rb
+++ b/lib/schema_dot_org/discussion_forum_posting.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'date'
-
 require_relative 'person'
 #
 # Model the Schema.org `Thing > CreativeWork > Article > SocialMediaPosting > DiscussionForumPosting`.  See https://schema.org/DiscussionForumPosting
@@ -9,7 +7,7 @@ require_relative 'person'
 module SchemaDotOrg
   class DiscussionForumPosting < SchemaType
     validated_attr :author,        type: Person, presence: true
-    validated_attr :datePublished, type: Date,   presence: true
+    validated_attr :datePublished, type: String, presence: true
 
     validated_attr :comment,              type: Array,   allow_nil: true
     validated_attr :commentCount,         type: Numeric, allow_nil: true

--- a/spec/schema_dot_org/comment_spec.rb
+++ b/spec/schema_dot_org/comment_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe SchemaDotOrg::Comment do
     SchemaDotOrg::Comment.new(
       text: 'This is a great comment!',
       author: SchemaDotOrg::Person.new(name: 'Alice'),
-      datePublished: Date.new(2020, 1, 1),
+      datePublished: '2020-01-01',
       image: ['https://example.com/image.jpg'],
       url: 'https://example.com/post',
       comment: [SchemaDotOrg::Comment.new(
         text: 'Great comment!',
         author: SchemaDotOrg::Person.new(name: 'Bob'),
-        datePublished: Date.new(2020, 1, 2),
+        datePublished: '2020-01-02',
         url: 'https://example.com/comment',
         )
       ],

--- a/spec/schema_dot_org/discussion_forum_posting_spec.rb
+++ b/spec/schema_dot_org/discussion_forum_posting_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe SchemaDotOrg::DiscussionForumPosting do
       headline: 'Great Post',
       text: 'This is a great post!',
       author: SchemaDotOrg::Person.new(name: 'Alice'),
-      datePublished: Date.new(2020, 1, 1),
+      datePublished: '2020-01-01',
       image: ['https://example.com/image.jpg'],
       url: 'https://example.com/post',
       mainEntityOfPage: 'https://example.com/post',
       comment: [SchemaDotOrg::Comment.new(
         text: 'Great comment!',
         author: SchemaDotOrg::Person.new(name: 'Bob'),
-        datePublished: Date.new(2020, 1, 2),
+        datePublished: '2020-01-01',
         url: 'https://example.com/comment',
         )
       ],
@@ -49,7 +49,7 @@ RSpec.describe SchemaDotOrg::DiscussionForumPosting do
             '@type' => 'Comment',
             'text' => 'Great comment!',
             'author' => { '@type' => 'Person', 'name' => 'Bob' },
-            'datePublished' => '2020-01-02',
+            'datePublished' => '2020-01-01',
             'url' => 'https://example.com/comment',
           }
         ],


### PR DESCRIPTION
Only for `DisccusionForumPosting` for now. But all Date should be replaced as a string