### PR TITLE
Reject @context_for_validations from attrs

### DIFF
--- a/lib/schema_dot_org.rb
+++ b/lib/schema_dot_org.rb
@@ -98,7 +98,7 @@ module SchemaDotOrg
 
 
     def attrs
-      instance_variables.reject{ |v| [:@validation_context, :@errors].include?(v) }
+      instance_variables.reject{ |v| %i[@context_for_validation @validation_context @errors].include?(v) }
     end
 
 


### PR DESCRIPTION
After Rails 7.1, 

`contextForValidation` was added on each instance making the json+ld structure incorrect.

Example: 

```json

{
  "@context": "https://schema.org",
  "@type": "DiscussionForumPosting",
  "headline": "test",
  "text": "foo",
  "author": {
    "@type": "Person",
    "name": "bd8d5",
    "contextForValidation": "#<ActiveModel::ValidationContext:0x000000012858f998>"
  },
  "datePublished": "2025-01-28T13:41:36+09:00",
  "url": "https://myapp.com/articles/24205",
  "mainEntityOfPage": "https://myapp.com/articles/24205",
  "inLanguage": [
    {
      "@type": "Language",
      "name": "France",
      "alternateName": "fr",
      "contextForValidation": "#<ActiveModel::ValidationContext:0x0000000128580a38>"
    }
  ],
  "interactionStatistic": [
    {
      "@type": "InteractionCounter",
      "userInteractionCount": 0,
      "interactionType": "https://schema.org/LikeAction",
      "contextForValidation": "#<ActiveModel::ValidationContext:0x00000001289a2328>"
    },
    {
      "@type": "InteractionCounter",
      "userInteractionCount": 0,
      "interactionType": "https://schema.org/ViewAction",
      "contextForValidation": "#<ActiveModel::ValidationContext:0x00000001289a1568>"
    }
  ],
  "contextForValidation": "#<ActiveModel::ValidationContext:0x00000001289a0578>"
}
```